### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,6 +11,7 @@
   ],
   "description" : "Print a table to the terminal and browse it interactively.",
   "name" : "Term::TablePrint",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "Term::TablePrint" : "lib/Term/TablePrint.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license